### PR TITLE
Add HuggingFace dataset support for I-JEPA

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,11 @@
             "LAYER_DROPOUT": 0.1
         },
         "dataset": {
-            "DATASET_PATH": "./data/image/imagenet/imagenet-object-localization-challenge/ILSVRC/Data/CLS-LOC",
+            "DATASET_PATH": null,
+            "HF_DATASET_ID": "PKU-Alignment/Align-Anything",
+            "HF_DATASET_NAME": "text-to-image",
+            "HF_TRAIN_SPLIT": "train",
+            "HF_VAL_SPLIT": "val",
             "ACCEPTABLE_FILE_EXTENSIONS": [".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"],
             "SHUFFLE_DATASET": true,
             "transforms": {

--- a/jepa_datasets/image/__init__.py
+++ b/jepa_datasets/image/__init__.py
@@ -1,3 +1,5 @@
 from .image_datamodule import *
 from .image_dataset import *
 from .image_transforms import *
+from .hf_image_dataset import *
+from .hf_image_datamodule import *

--- a/jepa_datasets/image/hf_image_datamodule.py
+++ b/jepa_datasets/image/hf_image_datamodule.py
@@ -1,0 +1,93 @@
+from typing import Any, Dict, Optional
+
+import pytorch_lightning as pl
+from torch.utils.data import DataLoader
+
+from configs import get_image_dataset_config
+
+from .hf_image_dataset import HFImageDataset
+
+
+dataset_config = get_image_dataset_config()
+
+
+class HFImageDataModule(pl.LightningDataModule):
+    def __init__(
+        self,
+        dataset_id: str,
+        subset_name: Optional[str],
+        train_split: str,
+        val_split: str,
+        batch_size: int,
+        num_workers: int,
+        pin_memory: bool,
+        persistent_workers: bool,
+        prefetch_factor: int,
+        shuffle: bool,
+    ) -> None:
+        super().__init__()
+        self.dataset_id = dataset_id
+        self.subset_name = subset_name
+        self.train_split = train_split
+        self.val_split = val_split
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
+        self.prefetch_factor = prefetch_factor
+        self.shuffle = shuffle
+
+        self.train_dataset = None
+        self.val_dataset = None
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        self.train_dataset = HFImageDataset(
+            dataset_id=self.dataset_id,
+            subset_name=self.subset_name,
+            split=self.train_split,
+        )
+        self.val_dataset = HFImageDataset(
+            dataset_id=self.dataset_id,
+            subset_name=self.subset_name,
+            split=self.val_split,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            prefetch_factor=self.prefetch_factor,
+            shuffle=self.shuffle,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            prefetch_factor=self.prefetch_factor,
+            shuffle=False,
+        )
+
+
+def create_hf_image_datamodule(image_config: Dict[str, Any]) -> HFImageDataModule:
+    dataset_cfg = image_config["dataset"]
+    exp_cfg = image_config["experiment"]
+
+    return HFImageDataModule(
+        dataset_id=dataset_cfg["HF_DATASET_ID"],
+        subset_name=dataset_cfg.get("HF_DATASET_NAME"),
+        train_split=dataset_cfg.get("HF_TRAIN_SPLIT", "train"),
+        val_split=dataset_cfg.get("HF_VAL_SPLIT", "val"),
+        batch_size=exp_cfg["BATCH_SIZE"],
+        num_workers=exp_cfg["NUM_WORKERS"],
+        pin_memory=exp_cfg["PIN_MEMORY"],
+        persistent_workers=exp_cfg["PERSISTENT_WORKERS"],
+        prefetch_factor=exp_cfg["PREFETCH_FACTOR"],
+        shuffle=dataset_cfg["SHUFFLE_DATASET"],
+    )

--- a/jepa_datasets/image/hf_image_dataset.py
+++ b/jepa_datasets/image/hf_image_dataset.py
@@ -1,0 +1,39 @@
+from typing import Optional
+
+from datasets import load_dataset
+from PIL import Image
+from torch.utils.data import Dataset as TorchDataset
+from torchvision import transforms
+
+from configs import get_image_dataset_config
+from .image_transforms import make_transforms
+
+dataset_config = get_image_dataset_config()
+
+
+class HFImageDataset(TorchDataset):
+    """Dataset wrapper for HuggingFace image datasets."""
+
+    def __init__(
+        self,
+        dataset_id: str,
+        subset_name: Optional[str],
+        split: str,
+        transform: Optional[transforms.Compose] = None,
+    ) -> None:
+        super().__init__()
+        self.dataset = load_dataset(dataset_id, name=subset_name, split=split)
+        self.transform = transform or transforms.Compose(make_transforms())
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int):
+        sample = self.dataset[idx]
+        image = sample.get("image")
+        if isinstance(image, Image.Image):
+            image = image.convert("RGB")
+        else:
+            # Some datasets return dict with 'bytes'
+            image = Image.open(image).convert("RGB")
+        return self.transform(image)

--- a/jepa_datasets/image/image_datamodule.py
+++ b/jepa_datasets/image/image_datamodule.py
@@ -7,6 +7,7 @@ from torch.utils.data import DataLoader
 from configs import get_image_dataset_config
 
 from .image_dataset import ImageDataset
+from .hf_image_datamodule import HFImageDataModule
 
 dataset_config = get_image_dataset_config()
 
@@ -103,6 +104,20 @@ class ImageDataModule(pl.LightningDataModule):
 def create_image_datamodule(image_config: Dict[str, Any]) -> ImageDataModule:
     _dataset_config: Dict[str, Any] = image_config["dataset"]
     experiment_config: Dict[str, Any] = image_config["experiment"]
+
+    if _dataset_config.get("HF_DATASET_ID"):
+        return HFImageDataModule(
+            dataset_id=_dataset_config["HF_DATASET_ID"],
+            subset_name=_dataset_config.get("HF_DATASET_NAME"),
+            train_split=_dataset_config.get("HF_TRAIN_SPLIT", "train"),
+            val_split=_dataset_config.get("HF_VAL_SPLIT", "val"),
+            batch_size=experiment_config["BATCH_SIZE"],
+            num_workers=experiment_config["NUM_WORKERS"],
+            pin_memory=experiment_config["PIN_MEMORY"],
+            persistent_workers=experiment_config["PERSISTENT_WORKERS"],
+            prefetch_factor=experiment_config["PREFETCH_FACTOR"],
+            shuffle=_dataset_config["SHUFFLE_DATASET"],
+        )
 
     return ImageDataModule(
         dataset_path=_dataset_config["DATASET_PATH"],

--- a/pretrain_IJEPA.py
+++ b/pretrain_IJEPA.py
@@ -4,11 +4,17 @@ from pytorch_lightning.loggers import TensorBoardLogger
 
 from configs import (
     get_image_config,
+    get_image_dataset_config,
     get_image_experiment_config,
     get_image_runtime_config,
     get_image_tracking_config,
 )
-from jepa_datasets import ImageDataModule, create_image_datamodule
+from jepa_datasets import (
+    ImageDataModule,
+    HFImageDataModule,
+    create_image_datamodule,
+    create_hf_image_datamodule,
+)
 from model import IJEPA
 from model.image import ijepa_model_builders
 
@@ -55,7 +61,11 @@ if __name__ == "__main__":
     print(f"✅ Model loaded: {model_id}")
 
     # 2. Load dataset
-    datamodule: ImageDataModule = create_image_datamodule(image_config=image_config)
+    dataset_cfg = get_image_dataset_config()
+    if dataset_cfg.get("HF_DATASET_ID"):
+        datamodule: HFImageDataModule = create_hf_image_datamodule(image_config=image_config)
+    else:
+        datamodule: ImageDataModule = create_image_datamodule(image_config=image_config)
     print("✅ Dataset loaded")
 
     # 3. Callbacks


### PR DESCRIPTION
## Summary
- add `HFImageDataset` and `HFImageDataModule` to load image data from HuggingFace datasets
- expose new dataset builders in the image package
- allow `create_image_datamodule` to return HuggingFace datamodule when `HF_DATASET_ID` is set
- update `pretrain_IJEPA.py` to choose dataset source automatically
- configure `config.json` to use the `PKU-Alignment/Align-Anything` dataset by default

## Testing
- `python -m py_compile pretrain_IJEPA.py jepa_datasets/image/hf_image_dataset.py jepa_datasets/image/hf_image_datamodule.py`

------
https://chatgpt.com/codex/tasks/task_e_686746e8710c832faeff055a347275a4