### PR TITLE
Add multimodal JEPA prototype

### DIFF
--- a/multimodal/__init__.py
+++ b/multimodal/__init__.py
@@ -1,0 +1,4 @@
+"""Modules for Multimodal JEPA."""
+from .datamodule import VQADatamodule
+from .model import MultimodalJEPA
+__all__ = ["VQADatamodule", "MultimodalJEPA"]

--- a/multimodal/datamodule.py
+++ b/multimodal/datamodule.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+import pytorch_lightning as pl
+import torch
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+from .dataset import VQADataset
+
+
+class VQADatamodule(pl.LightningDataModule):
+    """Lightning DataModule for the VQAv2 dataset."""
+
+    def __init__(
+        self,
+        batch_size: int = 32,
+        num_workers: int = 4,
+        pin_memory: bool = True,
+        persistent_workers: bool = False,
+        prefetch_factor: int = 2,
+        train_fraction: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.persistent_workers = persistent_workers
+        self.prefetch_factor = prefetch_factor
+        self.train_fraction = train_fraction
+        self.train_dataset: Optional[VQADataset] = None
+        self.val_dataset: Optional[VQADataset] = None
+
+    def setup(self, stage: Optional[str] = None) -> None:
+        image_transform = transforms.Compose(
+            [transforms.Resize(224), transforms.ToTensor()]
+        )
+        full_train = VQADataset("train", image_transform=image_transform)
+        num_train = int(len(full_train) * self.train_fraction)
+        self.train_dataset, self.val_dataset = (
+            torch.utils.data.random_split(
+                full_train, [num_train, len(full_train) - num_train]
+            )
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            prefetch_factor=self.prefetch_factor,
+            shuffle=True,
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            pin_memory=self.pin_memory,
+            persistent_workers=self.persistent_workers,
+            prefetch_factor=self.prefetch_factor,
+        )

--- a/multimodal/dataset.py
+++ b/multimodal/dataset.py
@@ -1,0 +1,38 @@
+from typing import Optional, Tuple
+
+from PIL import Image
+from torch.utils.data import Dataset
+from torchvision import transforms
+from datasets import load_dataset
+
+
+class VQADataset(Dataset):
+    """Dataset wrapping the VQAv2 data from Hugging Face.
+
+    Each item is a tuple of transformed image tensor and the raw text string.
+    """
+
+    def __init__(
+        self,
+        split: str,
+        image_transform: Optional[transforms.Compose] = None,
+    ) -> None:
+        super().__init__()
+
+        self.dataset = load_dataset("lmms-lab/VQAv2", split=split)
+        self.image_transform = image_transform or transforms.Compose(
+            [transforms.ToTensor()]
+        )
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int) -> Tuple[transforms.Tensor, str]:
+        sample = self.dataset[idx]
+        image = sample.get("image")
+        if not isinstance(image, Image.Image):
+            image = Image.open(image)
+        if self.image_transform:
+            image = self.image_transform(image)
+        question = sample.get("question") or sample.get("text")
+        return image, question

--- a/multimodal/model.py
+++ b/multimodal/model.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+import pytorch_lightning as pl
+import torch
+import torch.nn as nn
+from transformers import AutoModel, AutoTokenizer
+from model.vision.vit import vit_tiny
+
+
+class MultimodalJEPA(pl.LightningModule):
+    """Simple teacher–student JEPA aligning images with text."""
+
+    def __init__(
+        self,
+        text_model_name: str = "google-bert/bert-base-uncased",
+        lr: float = 1e-4,
+    ) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        self.tokenizer = AutoTokenizer.from_pretrained(text_model_name)
+        self.text_model = AutoModel.from_pretrained(text_model_name)
+        for p in self.text_model.parameters():
+            p.requires_grad = False
+        embed_dim = self.text_model.config.hidden_size
+        self.image_encoder = vit_tiny(img_size=224, patch_size=16)
+        self.proj = nn.Sequential(
+            nn.Linear(self.image_encoder.embed_dim, embed_dim),
+            nn.GELU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+        self.criterion = nn.MSELoss()
+        self.lr = lr
+
+    def forward(self, images: torch.Tensor, texts: list[str]):
+        text_inputs = self.tokenizer(texts, return_tensors="pt", padding=True, truncation=True).to(self.device)
+        with torch.no_grad():
+            text_outputs = self.text_model(**text_inputs)
+            text_emb = text_outputs.last_hidden_state[:, 0, :]  # CLS token
+        img_feat = self.image_encoder.forward_vit(images)
+        img_feat = img_feat.mean(dim=1)
+        pred = self.proj(img_feat)
+        loss = self.criterion(pred, text_emb)
+        return loss, pred, text_emb
+
+    def training_step(self, batch, batch_idx):
+        images, texts = batch
+        loss, _, _ = self(images, texts)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        images, texts = batch
+        loss, _, _ = self(images, texts)
+        self.log("val_loss", loss)
+        return loss
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(self.parameters(), lr=self.lr)
+        return optimizer

--- a/multimodal/pretrain_MJEPA.py
+++ b/multimodal/pretrain_MJEPA.py
@@ -1,0 +1,23 @@
+import pytorch_lightning as pl
+from pytorch_lightning.callbacks import ModelCheckpoint, LearningRateMonitor
+from pytorch_lightning.loggers import TensorBoardLogger
+
+from .datamodule import VQADatamodule
+from .model import MultimodalJEPA
+
+
+if __name__ == "__main__":
+    datamodule = VQADatamodule()
+    model = MultimodalJEPA()
+
+    checkpoint = ModelCheckpoint(dirpath="checkpoints", save_top_k=1, monitor="val_loss")
+    lr_monitor = LearningRateMonitor(logging_interval="step")
+    logger = TensorBoardLogger("logs", name="multimodal_jepa")
+
+    trainer = pl.Trainer(
+        max_epochs=1,
+        callbacks=[checkpoint, lr_monitor],
+        logger=logger,
+    )
+
+    trainer.fit(model, datamodule=datamodule)


### PR DESCRIPTION
## Summary
- implement `MultimodalJEPA` prototype for predicting BERT text embeddings from images
- include dataset and datamodule for VQAv2
- add training script `pretrain_MJEPA.py`

## Testing
- `python -m py_compile multimodal/*.py`
- *(failed to run dataset setup due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6882e7d8fbf0832fbb424eeaa844e216